### PR TITLE
Fix compression_ratio type error

### DIFF
--- a/auto_process.py
+++ b/auto_process.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
     )
     parser.add_argument(
         "--compression_ratio",
-        type=int,
+        type=float,
         default=0.3
     )
     parser.add_argument(


### PR DESCRIPTION
Slack link: https://nota-workspace.slack.com/archives/C040F65LSAJ/p1700551133153389?thread_ts=1700539898.418389&cid=C040F65LSAJ

목적
---
- arguments 중 `compression_ratio`의 입력 type을 수정

변경 사항
---
- arguments 중 `compression_ratio`의 입력 type을 수정

참조
---
